### PR TITLE
Incomplete sentence

### DIFF
--- a/SaDS_17/concepts.tex
+++ b/SaDS_17/concepts.tex
@@ -80,7 +80,7 @@ In addition to plain design or implementation errors, there may be failures in h
 
 Together with correctness, safety is the only property that is at least in principle accessible to a formal definition.
 But the resulting problem is undecidable.
-So in practice, we have to use to extensive testsmust be established in complex 
+So in practice, we have to use to extensive testing.  
 
 Security is very to prove because any proof must make assumptions about what kind of attacks there are.
 Attacking a system often requires intentionally violating the specification and supply unanticipated input.


### PR DESCRIPTION
Incomplete sentence Section 2.1.3, third paragraph. 
Original sentence: "So in practice, we have to use to extensive testsmust be established in complex".
Suggested fix: "So in practice, we have to use to extensive testing".

It is not clear what is implied.